### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ User stories can be completed by completing each task in the given sequence spec
 
 ### Modelling errors and rework
 
-We do not simuate errors, instead we model the rework necessary to fix the errors.
+We do not simulate errors, instead we model the rework necessary to fix the errors.
 
-![We do not simuate errors, instead we model the rework necessary to fix the errors](images/Rework.png)
+![We do not simulate errors, instead we model the rework necessary to fix the errors](images/Rework.png)
 
 ### Modelling the software development process
 


### PR DESCRIPTION
## Summary
- fix `simulate` spelling in README section about errors

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d745af750832699f43519535ef75d